### PR TITLE
Fix start script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,12 @@
 {
   "name": "my-celiac-adventure",
+  "version": "0.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
+      "version": "0.0.1",
+      "license": "ISC",
       "dependencies": {
         "nodemon": "^2.0.7"
       }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.1",
   "description": "",
   "main": "server/server.js",
- 
   "repository": {
     "type": "git",
     "url": "git+https://github.com/jeffreyclu/my-celiac-adventure.git"
@@ -28,6 +27,6 @@
     "dev:client": "cd client && npm run start",
     "prod:server": "NODE_ENV=production node server/server.js",
     "build:client": "cd client && npm run build",
-    "start": "npm run prod:server"
+    "start": "npm i && npm run build:client && npm run prod:server"
   }
 }


### PR DESCRIPTION
According to heroku build logs, `express` module is not being recognized. This fix adds an `npm i` step prior to starting server.